### PR TITLE
Prioritize relative paths for finding TS1

### DIFF
--- a/Client/Simitone/Simitone.Windows/GameLocator/LinuxLocator.cs
+++ b/Client/Simitone/Simitone.Windows/GameLocator/LinuxLocator.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 
 namespace Simitone.Windows.GameLocator
 {
@@ -9,11 +7,18 @@ namespace Simitone.Windows.GameLocator
     {
         public string FindTheSimsOnline()
         {
-            return "game/TSOClient/";
+            return "";
+            //string localDir = @"../The Sims Online/TSOClient/";
+            //if (File.Exists(Path.Combine(localDir, "tuning.dat"))) return localDir;
+
+            //return "game/TSOClient/";
         }
 
         public string FindTheSims1()
         {
+            string localDir = @"../The Sims/";
+            if (File.Exists(Path.Combine(localDir, "GameData", "Behavior.iff"))) return localDir;
+
             return "game1/";
         }
     }

--- a/Client/Simitone/Simitone.Windows/GameLocator/MacOSLocator.cs
+++ b/Client/Simitone/Simitone.Windows/GameLocator/MacOSLocator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Simitone.Windows.GameLocator
 {
@@ -6,11 +7,18 @@ namespace Simitone.Windows.GameLocator
     {
         public string FindTheSimsOnline()
         {
-            return string.Format("{0}/Documents/The Sims Online/TSOClient/", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+            return "";
+            //string localDir = @"../The Sims Online/TSOClient/";
+            //if (File.Exists(Path.Combine(localDir, "tuning.dat"))) return localDir;
+
+            //return string.Format("{0}/Documents/The Sims Online/TSOClient/", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
         }
 
         public string FindTheSims1()
         {
+            string localDir = @"../The Sims/";
+            if (File.Exists(Path.Combine(localDir, "GameData", "Behavior.iff"))) return localDir;
+
             return "game1/";
         }
     }

--- a/Client/Simitone/Simitone.Windows/GameLocator/WindowsLocator.cs
+++ b/Client/Simitone/Simitone.Windows/GameLocator/WindowsLocator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -13,35 +14,37 @@ namespace Simitone.Windows.GameLocator
         public string FindTheSimsOnline()
         {
             return "";
-            string Software = "";
+            //string Software = "";
 
-            using (var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
-            {
-                //Find the path to TSO on the user's system.
-                RegistryKey softwareKey = hklm.OpenSubKey("SOFTWARE");
+            //using (var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            //{
+            //    //Find the path to TSO on the user's system.
+            //    RegistryKey softwareKey = hklm.OpenSubKey("SOFTWARE");
 
-                if (Array.Exists(softwareKey.GetSubKeyNames(), delegate (string s) { return s.Equals("Maxis", StringComparison.InvariantCultureIgnoreCase); }))
-                {
-                    RegistryKey maxisKey = softwareKey.OpenSubKey("Maxis");
-                    if (Array.Exists(maxisKey.GetSubKeyNames(), delegate (string s) { return s.Equals("The Sims Online", StringComparison.InvariantCultureIgnoreCase); }))
-                    {
-                        RegistryKey tsoKey = maxisKey.OpenSubKey("The Sims Online");
-                        string installDir = (string)tsoKey.GetValue("InstallDir");
-                        installDir += "\\TSOClient\\";
-                        return installDir.Replace('\\', '/');
-                    }
-                }
-            }
-            return @"C:\Program Files\Maxis\The Sims Online\TSOClient\".Replace('\\', '/');
+            //    if (Array.Exists(softwareKey.GetSubKeyNames(), delegate (string s) { return s.Equals("Maxis", StringComparison.InvariantCultureIgnoreCase); }))
+            //    {
+            //        RegistryKey maxisKey = softwareKey.OpenSubKey("Maxis");
+            //        if (Array.Exists(maxisKey.GetSubKeyNames(), delegate (string s) { return s.Equals("The Sims Online", StringComparison.InvariantCultureIgnoreCase); }))
+            //        {
+            //            RegistryKey tsoKey = maxisKey.OpenSubKey("The Sims Online");
+            //            string installDir = (string)tsoKey.GetValue("InstallDir");
+            //            installDir += "\\TSOClient\\";
+            //            return installDir.Replace('\\', '/');
+            //        }
+            //    }
+            //}
+            //return @"C:\Program Files\Maxis\The Sims Online\TSOClient\".Replace('\\', '/');
         }
 
         public string FindTheSims1()
         {
-            string Software = "";
+            // Search relative directory similar to how macOS and Linux works; allows portability
+            string localDir = @"../The Sims/";
+            if (File.Exists(Path.Combine(localDir, "GameData", "Behavior.iff"))) return localDir;
 
             using (var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
             {
-                //Find the path to TSO on the user's system.
+                //Find the path to TS1 on the user's system.
                 RegistryKey softwareKey = hklm.OpenSubKey("SOFTWARE");
 
                 if (Array.Exists(softwareKey.GetSubKeyNames(), delegate (string s) { return s.Equals("Maxis", StringComparison.InvariantCultureIgnoreCase); }))
@@ -56,6 +59,7 @@ namespace Simitone.Windows.GameLocator
                     }
                 }
             }
+            // Fall back to the default install location if the other two checks fail
             return @"C:\Program Files (x86)\Maxis\The Sims\".Replace('\\', '/');
         }
 


### PR DESCRIPTION
Keeps the logic here consistent with FreeSO.

Opted to look for `Behavior.iff` in the folder since `tuning.dat` doesn't exist.