### PR TITLE
Updating code to handle animation loading errors from custom content more gracefully.  Also fixed an issue where DPI scaling wasn't working properly.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build Simitone
+
+on:
+  workflow_dispatch:
+    inputs:
+      configuration:
+        description: 'Build configuration'
+        required: false
+        default: 'Release'
+        type: choice
+        options:
+          - Release
+          - Debug
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Run Protobuild
+      shell: pwsh
+      run: |
+        cd FreeSO/Other/libs/FSOMonoGame/
+        ./protobuild.exe --generate
+      continue-on-error: true
+
+    - name: Restore Simitone dependencies
+      run: dotnet restore Client/Simitone/Simitone.sln
+
+    - name: Restore FreeSO dependencies
+      run: dotnet restore FreeSO/TSOClient/FreeSO.sln
+      continue-on-error: true
+
+    - name: Restore Roslyn dependencies
+      shell: pwsh
+      run: |
+        cd FreeSO/TSOClient/FSO.SimAntics.JIT.Roslyn/
+        dotnet restore
+      continue-on-error: true
+
+    - name: Build
+      run: dotnet build Client/Simitone/Simitone.sln -c ${{ inputs.configuration || 'Release' }} --no-restore
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: SimitoneWindows-${{ inputs.configuration || 'Release' }}
+        path: Client/Simitone/Simitone.Windows/bin/${{ inputs.configuration || 'Release' }}/net9.0-windows/
+        if-no-files-found: error

--- a/Client/Simitone/Simitone.Client/GameController.cs
+++ b/Client/Simitone/Simitone.Client/GameController.cs
@@ -1,7 +1,10 @@
 ﻿using FSO.Client;
 using FSO.Client.UI.Framework;
+using FSO.Client.UI.Controls;
 using FSO.Common.Utils;
+using FSO.Content;
 using Simitone.Client.UI.Screens;
+using Simitone.Client.UI.Panels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,7 +59,74 @@ namespace Simitone.Client
                     }
                 }
                 screen.Initialize(lotName, external);
+                
+                // Show notification about any failed content files
+                ShowFailedContentNotification();
             });
+        }
+        
+        /// <summary>
+        /// Shows a notification to the user about any content files that failed to load.
+        /// This is called after entering game mode so the user can see which custom content
+        /// files are problematic.
+        /// </summary>
+        private static void ShowFailedContentNotification()
+        {
+            var failedFiles = Content.FailedContentFiles;
+            if (failedFiles == null || failedFiles.Count == 0)
+                return;
+            
+            var realFailures = failedFiles
+                .Where(f => f.ErrorType != "DebugInfo")
+                .GroupBy(f => f.Filename)
+                .Select(g => g.First())
+                .ToList();
+            
+            if (realFailures.Count == 0)
+                return;
+            
+            var message = new StringBuilder();
+            message.AppendLine("Some custom content files could not be loaded:");
+            message.AppendLine();
+            
+            int displayCount = Math.Min(realFailures.Count, 3);
+            for (int i = 0; i < displayCount; i++)
+            {
+                var file = realFailures[i];
+                string shortReason = file.ErrorType switch
+                {
+                    "EndOfStream" => "truncated",
+                    "InvalidData" => "invalid format",
+                    "IOException" => "I/O error",
+                    "CatalogError" => "catalog error",
+                    "DecodeError" => "decode failed",
+                    _ => file.ErrorType
+                };
+                message.AppendLine($"• {file.Filename} ({shortReason})");
+            }
+            
+            if (realFailures.Count > 3)
+            {
+                message.AppendLine($"... and {realFailures.Count - 3} more");
+            }
+            
+            message.AppendLine();
+            message.AppendLine("Common causes: corrupted files, missing .cfp files, or wrong format.");
+            message.AppendLine("The game will continue without these items.");
+            
+            // Show the alert
+            UIMobileAlert alert = null;
+            alert = new UIMobileAlert(new UIAlertOptions
+            {
+                Title = "Custom Content Warning",
+                Message = message.ToString(),
+                Buttons = UIAlertButton.Ok((btn) => 
+                { 
+                    alert.Close();
+                })
+            });
+            
+            UIScreen.GlobalShowDialog(alert, true);
         }
 
         public static void EnterCAS()

--- a/Client/Simitone/Simitone.Client/SimitoneGame.cs
+++ b/Client/Simitone/Simitone.Client/SimitoneGame.cs
@@ -47,11 +47,13 @@ namespace Simitone.Client
             FSOEnvironment.TexCompress = false;
             UILotControl.ShowSimanticsExceptions = !FSOEnvironment.Args.Contains("nosimantics-exc");
 
+            FSOEnvironment.DPIScaleFactor = GlobalSettings.Default.DPIScaleFactor;
+
             if (!FSOEnvironment.SoftwareKeyboard)
             {
                 Graphics.SynchronizeWithVerticalRetrace = true;
-                Graphics.PreferredBackBufferWidth = GlobalSettings.Default.GraphicsWidth;
-                Graphics.PreferredBackBufferHeight = GlobalSettings.Default.GraphicsHeight;
+                Graphics.PreferredBackBufferWidth = (int)(GlobalSettings.Default.GraphicsWidth * FSOEnvironment.DPIScaleFactor);
+                Graphics.PreferredBackBufferHeight = (int)(GlobalSettings.Default.GraphicsHeight * FSOEnvironment.DPIScaleFactor);
                 Graphics.HardwareModeSwitch = false;
                 Graphics.ApplyChanges();
             }
@@ -82,6 +84,8 @@ namespace Simitone.Client
             if (uiLayer?.CurrentUIScreen == null) return;
 
             uiLayer.SpriteBatch.ResizeBuffer(GlobalSettings.Default.GraphicsWidth, GlobalSettings.Default.GraphicsHeight);
+            GlobalSettings.Default.GraphicsWidth = (int)(width / FSOEnvironment.DPIScaleFactor);
+            GlobalSettings.Default.GraphicsHeight = (int)(height / FSOEnvironment.DPIScaleFactor);
             uiLayer.CurrentUIScreen.GameResized();
         }
 

--- a/Client/Simitone/Simitone.Windows/Simitone.Windows.csproj
+++ b/Client/Simitone/Simitone.Windows/Simitone.Windows.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Simitone</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/Client/Simitone/Simitone.Windows/app.manifest
+++ b/Client/Simitone/Simitone.Windows/app.manifest
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Simitone.Windows"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>

--- a/Client/Simitone/Simitone.Windows/app.manifest
+++ b/Client/Simitone/Simitone.Windows/app.manifest
@@ -23,7 +23,7 @@
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
 
-      <!-- Windows 10 -->
+      <!-- Windows 10 annnd Windows 11 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>


### PR DESCRIPTION
<img width="1014" height="806" alt="image" src="https://github.com/user-attachments/assets/0ce70bbf-599b-4ed7-a7f2-c844488ad3fd" />

[A user reported an issue that pre-dated my fork](https://github.com/alexjyong/Simitone/issues/17) that custom animations would keep the game from loading. 

While I was unable at this time to determine why animations that worked in TS1 didn't work in Simitone, I added in a way for this to handle bad loading more gracefully. 

Also fixed an issue where on Windows DPI scaling wasn't working properly on load.

Currently pointed at my forked FreeSO for testing purposes. If/when my PR is accepted, I'll update this to point at the upstream FreeSo repo
https://github.com/riperiperi/FreeSO/pull/293